### PR TITLE
fixes: no server response when user sends the same msg twice in a row

### DIFF
--- a/client/src/components/ChatForm.tsx
+++ b/client/src/components/ChatForm.tsx
@@ -30,6 +30,11 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+interface OutboundChat {
+  text: string;
+  seq: number;
+}
+
 const ChatForm = (props: {
   lesson: string;
   username: string;
@@ -44,7 +49,10 @@ const ChatForm = (props: {
 }): JSX.Element => {
   const styles = useStyles();
   const [chat, setChat] = useState("");
-  const [outboundChat, setOutboundChat] = useState("");
+  const [outboundChat, setOutboundChat] = useState<OutboundChat>({
+    text: "",
+    seq: 0,
+  });
   const [sessionAlive, setSessionAlive] = useState(true);
 
   useEffect(() => {
@@ -57,7 +65,7 @@ const ChatForm = (props: {
           lesson: props.lesson,
           username: props.username,
           session: props.session,
-          outboundChat: outboundChat,
+          outboundChat: outboundChat.text,
         });
         if (response.status !== 200) {
           props.setErrorProps(
@@ -106,7 +114,10 @@ const ChatForm = (props: {
         ...props.messages,
         { senderId: "user", type: "", text: chat },
       ]);
-      setOutboundChat(chat);
+      setOutboundChat({
+        text: chat,
+        seq: outboundChat.seq + 1,
+      });
       setChat("");
     }
   }

--- a/cypress/cypress/fixtures/q2-1-p2-no-completion.json
+++ b/cypress/cypress/fixtures/q2-1-p2-no-completion.json
@@ -1,0 +1,38 @@
+{
+  "status": "ok",
+  "sessionInfo": {
+    "sessionId": "8c13c9e0-8b4e-4a6d-b650-f41d82ebe454",
+    "sessionHistory": "{\"userResponses\":[\"Current flows in the same direction as the arrow\"]],\"userScores\":[],\"classifierGrades\":[{\"expectationResults\":[{\"evaluation\":\"Good\",\"expectation\":0,\"score\":0.7877823480773107}]}]}",
+    "previousUserResponse": "Current flows in the same direction as the arrow",
+    "previousSystemResponse": [
+      "Summing up, this diode is forward biased. Positive current flows in the same direction of the arrow, from anode to cathode.",
+      "Let's try a different problem."
+    ],
+    "dialogState": {
+      "expectationsCompleted": [false],
+      "expectationData": [
+        {
+          "ideal": "",
+          "score": 0,
+          "satisfied": false,
+          "status": ""
+        }
+      ],
+      "hints": false
+    },
+    "hash": "807c0483cbaa95e0e7e7a1b8908e04f6ecb2d83a66c2d2d27e0496063c0f976b"
+  },
+  "response": [
+    {
+      "author": "them",
+      "type": "text",
+      "data": {
+        "text": "some server response."
+      }
+    }
+  ],
+  "sentToGrader": true,
+  "completed": false,
+  "score": null,
+  "expectationActive": -1
+}

--- a/cypress/cypress/integration/input.spec.ts
+++ b/cypress/cypress/integration/input.spec.ts
@@ -20,9 +20,7 @@ describe("Input field", () => {
     cyMockDialog(cy, "q1", "q1-1-p1.json");
     cyMockSession(cy, "q1", "q1-1-p2.json");
     cy.visit("/?lesson=q1&guest=guest");
-    cy.get("#outlined-multiline-static").type(
-      "fake short answer."
-    );
+    cy.get("#outlined-multiline-static").type("fake short answer.");
     cy.get("#submit-button").click();
     cy.get("#submit-button").should("be.disabled");
     cy.get("#outlined-multiline-static").should("be.disabled");
@@ -40,25 +38,56 @@ describe("Input field", () => {
   it("can send input with button", () => {
     cySetup(cy);
     cyMockDialog(cy, "q2", "q2-1-p1.json");
-    cyMockSession(cy, "q2", "q2-1-p2.json");
+    cyMockSession(cy, "q2", "q2-1-p2.json").as("session");;
     cy.visit("/?lesson=q2&guest=guest");
     const userInput = "some fake answer";
-    cy.get("#outlined-multiline-static").should("be.visible")
+    cy.get("#outlined-multiline-static").should("be.visible");
     cy.get("#outlined-multiline-static").type(userInput);
-    cy.get("#submit-button").should("be.visible")
+    cy.get("#submit-button").should("be.visible");
     cy.get("#submit-button").click();
     cy.get("#chat-msg-3").contains(userInput);
+    cy.wait("@session");
+    cy.get("#chat-msg-4").contains(
+      "Summing up, this diode is forward biased. Positive current flows in the same direction of the arrow, from anode to cathode."
+    );
   });
 
   it("can send input with enter", () => {
     cySetup(cy);
     cyMockDialog(cy, "q2", "q2-1-p1.json");
-    cyMockSession(cy, "q2", "q2-1-p2.json");
+    cyMockSession(cy, "q2", "q2-1-p2.json").as("session");;
     cy.visit("/?lesson=q2&guest=guest");
     const userInput = "another fake answer";
-    cy.get("#outlined-multiline-static").should("be.visible")
+    cy.get("#outlined-multiline-static").should("be.visible");
     cy.get("#outlined-multiline-static").type(userInput);
     cy.get("#outlined-multiline-static").type("{enter}");
     cy.get("#chat-msg-3").contains(userInput);
+    cy.wait("@session");
+    cy.get("#chat-msg-4").contains(
+      "Summing up, this diode is forward biased. Positive current flows in the same direction of the arrow, from anode to cathode."
+    );
+  });
+
+  it("ensure can send same input twice in a row", () => {
+    cySetup(cy);
+    cyMockDialog(cy, "q2", "q2-1-p1.json");
+    cyMockSession(cy, "q2", "q2-1-p2-no-completion").as("session");
+    cy.visit("/?lesson=q2&guest=guest");
+    const userInput = "answer we will repeat";
+    cy.get("#outlined-multiline-static").should("be.visible");
+    cy.get("#outlined-multiline-static").type(userInput);
+    cy.get("#outlined-multiline-static").type("{enter}");
+    cy.get("#chat-msg-3").contains(userInput);
+    cy.wait("@session");
+    cy.get("#chat-msg-4").contains(
+      "some server response."
+    );
+    cy.get("#outlined-multiline-static").type(userInput);
+    cy.get("#outlined-multiline-static").type("{enter}");
+    cy.get("#chat-msg-5").contains(userInput);
+    cy.wait("@session");
+    cy.get("#chat-msg-6").contains(
+      "some server response."
+    );
   });
 });


### PR DESCRIPTION
Fixes this bug:

https://app.asana.com/0/1196733706888425/1199576626228357

The issue was that a React `useEffect` hook that actually sends user messages to the server was using the message text as the object that needs to change for the effect to trigger. The fix here is to add a message seq number so that state will change even if the message text does not.