### PR TITLE
make rule for 'format' handles both prettier formatting and license check/set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,14 @@ docker-build:
 		--build-arg "OPENTUTOR_CLIENT_VERSION=$(OPENTUTOR_CLIENT_VERSION)" \
 	.
 
-.PHONY: format
-format: node_modules/prettier
-	npm run format
+PHONY: format
+format: LICENSE LICENSE_HEADER node_modules/license-check-and-add
+	npm ci && npm run license:fix
+	cd client && $(MAKE) format
+
+PHONY: pretty
+pretty:
+	cd client && $(MAKE) format
 
 LICENSE:
 	@echo "you must have a LICENSE file" 1>&2

--- a/client/Makefile
+++ b/client/Makefile
@@ -15,7 +15,7 @@ develop: .env.development node_modules/gatsby-cli
 
 .PHONY: format
 format:
-	cd .. && $(MAKE) format
+	npm run format
 
 .PHONY: license
 license:


### PR DESCRIPTION
Currently, there's "make format". We should have a new rule "make pretty".

Basically, "make format" will do pretty and license.