### PR TITLE
impr: max lint warnings 0

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -54,7 +54,7 @@
     "test": "echo 'all tests currently cypress'",
     "test:audit": "npm audit --audit-level=moderate --production",
     "test:cypress": "npx run cy:run --spec 'cypress/**/*.spec.js'",
-    "test:lint": "eslint src --ext ts --ext tsx --ext js --ext jsx",
+    "test:lint": "eslint src --ext ts --ext tsx --ext js --ext jsx --max-warnings=0",
     "test:types": "tsc --noEmit"
   },
   "repository": {


### PR DESCRIPTION
Just noticed we have lint warnings in some other PRs that aren't triggering commit to fail. 

This will make GHA tests will fail if any lint warnings